### PR TITLE
optimized redundant int array

### DIFF
--- a/customerimporter/interview_test.go
+++ b/customerimporter/interview_test.go
@@ -20,9 +20,9 @@ func TestImportDataSort(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	for i, v := range data {
-		if v.Domain != sortedDomains[i] {
-			t.Errorf("data not sorted properly. mismatch:\nhave: %v\nwant: %v", v.Domain, sortedDomains[i])
+	for i, v := range data.sortKeys() {
+		if v != sortedDomains[i] {
+			t.Errorf("data not sorted properly. mismatch:\nhave: %v\nwant: %v", v, sortedDomains[i])
 		}
 	}
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 
 	"github.com/MateuszDobron/teamwork/customerimporter"
 )
@@ -23,9 +22,9 @@ func NewCustomerExporter(outputPath *string) *CustomerExporter {
 
 // ExportData writes sorted customer domain data to a CSV file. If file already exists, it will
 // be truncated.
-func (ex CustomerExporter) ExportData(data []customerimporter.DomainData) error {
-	if data == nil {
-		return fmt.Errorf("error provided data is empty (nil)")
+func (ex CustomerExporter) ExportData(data customerimporter.DomainCounts) error {
+	if len(data.DomainMap) == 0 {
+		return fmt.Errorf("error provided data is empty 0 length")
 	}
 	outputFile, err := os.Create(*ex.outputPath)
 	if err != nil {
@@ -35,7 +34,7 @@ func (ex CustomerExporter) ExportData(data []customerimporter.DomainData) error 
 	return exportCsv(data, outputFile)
 }
 
-func exportCsv(data []customerimporter.DomainData, output io.Writer) error {
+func exportCsv(data customerimporter.DomainCounts, output io.Writer) error {
 	headers := []string{"domain", "number_of_customers"}
 	csvWriter := csv.NewWriter(output)
 	defer func() error {
@@ -48,11 +47,5 @@ func exportCsv(data []customerimporter.DomainData, output io.Writer) error {
 	if err := csvWriter.Write(headers); err != nil {
 		return err
 	}
-	for _, v := range data {
-		pair := []string{v.Domain, strconv.FormatUint(v.CustomerQuantity, 10)}
-		if err := csvWriter.Write(pair); err != nil {
-			return err
-		}
-	}
-	return nil
+	return data.CsvDomainCounts(csvWriter)
 }

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -9,31 +9,17 @@ import (
 
 func TestExportData(t *testing.T) {
 	path := "./test_output.csv"
-	data := []customerimporter.DomainData{
-		{
-			Domain:           "livejournal.com",
-			CustomerQuantity: 12,
-		},
-		{
-			Domain:           "microsoft.com",
-			CustomerQuantity: 22,
-		},
-		{
-			Domain:           "newsvine.com",
-			CustomerQuantity: 15,
-		},
-		{
-			Domain:           "pinteres.uk",
-			CustomerQuantity: 10,
-		},
-		{
-			Domain:           "yandex.ru",
-			CustomerQuantity: 43,
-		},
+	dc := customerimporter.NewDomainCounts()
+	dc.DomainMap = map[string]uint64{
+		"livejournal.com": 12,
+		"microsoft.com":   22,
+		"newsvine.com":    15,
+		"pinteres.uk":     10,
+		"yandex.ru":       43,
 	}
 	exporter := NewCustomerExporter(&path)
 
-	err := exporter.ExportData(data)
+	err := exporter.ExportData(dc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +29,7 @@ func TestExportInvalidPath(t *testing.T) {
 	path := ""
 	exporter := NewCustomerExporter(&path)
 
-	err := exporter.ExportData([]customerimporter.DomainData{})
+	err := exporter.ExportData(customerimporter.DomainCounts{})
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -54,7 +40,7 @@ func TestExportEmptyData(t *testing.T) {
 	path := "./test_output.csv"
 	exporter := NewCustomerExporter(&path)
 
-	err := exporter.ExportData(nil)
+	err := exporter.ExportData(customerimporter.NewDomainCounts())
 	if err == nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 
 	"log/slog"
 
@@ -32,18 +31,11 @@ func main() {
 		return
 	}
 	if *opts.outFile == "" {
-		printData(data)
+		data.PrintDomainCounts()
 	} else {
 		exporter := exporter.NewCustomerExporter(opts.outFile)
 		if saveErr := exporter.ExportData(data); saveErr != nil {
 			slog.Error("error saving domain data: ", saveErr)
 		}
-	}
-}
-
-func printData(data []customerimporter.DomainData) {
-	fmt.Println("domain,number_of_customers")
-	for _, v := range data {
-		fmt.Printf("%s,%v\n", v.Domain, v.CustomerQuantity)
 	}
 }


### PR DESCRIPTION
It is possible to print the sorted array without allocating additional int array. We need only slice of strings to sort the keys and then  lookup values from map, which is done in place. It would be beneficial when dealing with large inputs.