### PR TITLE
removed redundant pointer in CustomerExporter

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -10,12 +10,12 @@ import (
 )
 
 type CustomerExporter struct {
-	outputPath *string
+	outputPath string
 }
 
 // NewCustomerExporter returns a new CustomerExporter that writes customer domain data to specified file.
-func NewCustomerExporter(outputPath *string) *CustomerExporter {
-	return &CustomerExporter{
+func NewCustomerExporter(outputPath string) CustomerExporter {
+	return CustomerExporter{
 		outputPath: outputPath,
 	}
 }
@@ -26,7 +26,7 @@ func (ex CustomerExporter) ExportData(data customerimporter.DomainCounts) error 
 	if len(data.DomainMap) == 0 {
 		return fmt.Errorf("error provided data is empty 0 length")
 	}
-	outputFile, err := os.Create(*ex.outputPath)
+	outputFile, err := os.Create(ex.outputPath)
 	if err != nil {
 		return fmt.Errorf("error creating new file for saving: %v", err)
 	}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -17,7 +17,7 @@ func TestExportData(t *testing.T) {
 		"pinteres.uk":     10,
 		"yandex.ru":       43,
 	}
-	exporter := NewCustomerExporter(&path)
+	exporter := NewCustomerExporter(path)
 
 	err := exporter.ExportData(dc)
 	if err != nil {
@@ -27,7 +27,7 @@ func TestExportData(t *testing.T) {
 
 func TestExportInvalidPath(t *testing.T) {
 	path := ""
-	exporter := NewCustomerExporter(&path)
+	exporter := NewCustomerExporter(path)
 
 	err := exporter.ExportData(customerimporter.DomainCounts{})
 	if err == nil {
@@ -38,7 +38,7 @@ func TestExportInvalidPath(t *testing.T) {
 
 func TestExportEmptyData(t *testing.T) {
 	path := "./test_output.csv"
-	exporter := NewCustomerExporter(&path)
+	exporter := NewCustomerExporter(path)
 
 	err := exporter.ExportData(customerimporter.NewDomainCounts())
 	if err == nil {
@@ -57,7 +57,7 @@ func BenchmarkImportDomainData(b *testing.B) {
 	if err != nil {
 		b.Error(err)
 	}
-	exporter := NewCustomerExporter(&path)
+	exporter := NewCustomerExporter(path)
 
 	b.StartTimer()
 	b.ReportAllocs()

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ type Options struct {
 
 func readOptions() *Options {
 	opts := &Options{}
+	// default value is not nil
 	opts.path = flag.String("path", "./customers.csv", "Path to the file with customer data")
 	opts.outFile = flag.String("out", "", "Optional: output file path. If empty program will output results to the terminal")
 	flag.Parse()
@@ -33,7 +34,7 @@ func main() {
 	if *opts.outFile == "" {
 		data.PrintDomainCounts()
 	} else {
-		exporter := exporter.NewCustomerExporter(opts.outFile)
+		exporter := exporter.NewCustomerExporter(*opts.outFile)
 		if saveErr := exporter.ExportData(data); saveErr != nil {
 			slog.Error("error saving domain data: ", saveErr)
 		}


### PR DESCRIPTION
Removed redundant pointer to path, we do not parse json it cannot be nil, it is not a big struct so keep it as a value.