### PR TITLE
fix main naming ambiguity

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ func readOptions() *Options {
 
 func main() {
 	opts := readOptions()
-	importer := customerimporter.NewCustomerImporter(*opts.path)
-	data, err := importer.ImportDomainData()
+	imp := customerimporter.NewCustomerImporter(*opts.path)
+	data, err := imp.ImportDomainData()
 	if err != nil {
 		slog.Error("error importing customer data: ", slog.Any("err", err))
 		os.Exit(1)
@@ -35,8 +35,8 @@ func main() {
 	if *opts.outFile == "" {
 		data.PrintDomainCounts()
 	} else {
-		exporter := exporter.NewCustomerExporter(*opts.outFile)
-		if saveErr := exporter.ExportData(data); saveErr != nil {
+		exp := exporter.NewCustomerExporter(*opts.outFile)
+		if saveErr := exp.ExportData(data); saveErr != nil {
 			slog.Error("error saving domain data: ", slog.Any("err", saveErr))
 			os.Exit(1)
 		}


### PR DESCRIPTION
Previously the variable in main had the same name as the imported package, which is confusing.